### PR TITLE
Add generate uber jar tasks for end-to-end-tests (#381)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -243,8 +243,15 @@ configure(projectsToRelease) {
             }
         }
     }
-
     rootProject.release.dependsOn(release)
 }
 
+
+configure(project("end-to-end-tests")) {
+    task release(type: Copy) {
+        from tasks.getByPath(":end-to-end-tests:testJar")
+        into rootProject.file("build/blox-release/${project.name}")
+    }
+    rootProject.release.dependsOn(release)
+}
 

--- a/end-to-end-tests/build.gradle
+++ b/end-to-end-tests/build.gradle
@@ -1,8 +1,10 @@
 import com.amazonaws.blox.tasks.EndToEndTest
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     id "java"
     id "blox-deploy"
+    id 'com.github.johnrengelman.shadow' version '2.0.2'
 }
 
 sourceCompatibility = 1.8
@@ -30,6 +32,15 @@ deployment {
     s3Bucket stack.s3Bucket.toString()
 
     templateFile file("templates/test_cluster.yml")
+}
+
+task testJar(type: ShadowJar) {
+    group "build"
+    description "Generate uber jar for end to end testing"
+    classifier = 'tests'
+    from sourceSets.test.output
+    from sourceSets.main.output
+    configurations = [project.configurations.testRuntime]
 }
 
 task testEndToEnd(type: EndToEndTest) {

--- a/end-to-end-tests/src/test/java/com/amazonaws/blox/AbstractEndToEndTest.java
+++ b/end-to-end-tests/src/test/java/com/amazonaws/blox/AbstractEndToEndTest.java
@@ -31,7 +31,8 @@ public abstract class AbstractEndToEndTest {
 
   @Before
   public void setupBase() {
-    final String bloxEndpoint = System.getProperty("blox.tests.apiUrl");
+    final String bloxEndpoint =
+        System.getProperty("blox.tests.apiUrl", System.getenv("BLOX_TESTS_APIURL"));
     stack = new BloxTestStack(bloxEndpoint);
 
     environmentName = "EndToEndTestEnvironment_" + UUID.randomUUID();


### PR DESCRIPTION
* add generate uber jar for end-to-end-tests
on blox release, copy the uber jar to correct path

#### Summary
<!-- What does this pull request do? -->

#### Implementation details
<!-- How are the changes implemented? -->

#### Testing
<!-- How was this tested? -->

#### Licensing
This contribution is under the terms of the Apache 2.0 License: Yes
